### PR TITLE
Add v7 example to EdgeJS guide

### DIFF
--- a/src/guides/how-to.md
+++ b/src/guides/how-to.md
@@ -6,6 +6,6 @@ Learn how to perform common tasks.
 
 ## Node.js {/*nodejs*/}
 
-— <a href="/guides/install_nodejs">How to install Node.js</a>
+— [How to install Node.js](/guides/install_nodejs)
 
 ---

--- a/src/guides/performance/cdn_as_code/getting_started.md
+++ b/src/guides/performance/cdn_as_code/getting_started.md
@@ -314,6 +314,7 @@ Assess performance and caching behavior from the {{ PORTAL_LINK }}. Fine-tune yo
 
 [Learn more.](/guides/production)
 
+<!-- Pre v7 examples -->
 <Condition version="<7">
 
 ## Examples {/*example*/}
@@ -357,6 +358,25 @@ This example demonstrates a full-featured {{ PRODUCT }} configuration that showc
   siteUrl="https://edgio-community-examples-full-featured-performance-live.layer0-limelight.link/"
   repoUrl="https://github.com/edgio-docs/edgio-full-featured-performance-example/"
   deployFromRepo />
+
+</Condition>
+
+<!-- v7 examples -->
+<Condition version="7">
+
+## Examples {/*example*/}
+
+Use our sample websites to gain hands-on experience on how to set up {{ PRODUCT }} {{ PRODUCT_EDGE }}. Specifically, you can browse our sample websites, view their source code, and even experiment on them by deploying them to {{ PRODUCT }}.
+
+**Simple Example**
+
+This example demonstrates a basic {{ PRODUCT }} configuration for `publicdomainreview.org`. It contains two routes that cache content according to their file extension.
+
+<ExampleButtons
+  title="Simple"
+  siteUrl="https://edgio-community-examples-v7-simple-performance-live.edgio.link/"
+  repoUrl="https://github.com/edgio-docs/edgio-v7-simple-performance-example/"
+ />
 
 </Condition>
 


### PR DESCRIPTION
**NOTICE FOR DEPLOY TARGETS**

`main` is the (default) target branch for deploying to https://docs.edg.io relating to `@edgio` v5.x.

`main_v4` is the target branch for deploying to https://docs.layer0.co relating to `@layer0` 4.x.

If your change request applies to both versions, please create a pull request for both target branches.

-- You may remove this message --
