### PR TITLE
Added description for devtools and note for SW

### DIFF
--- a/src/guides/v7/sites_frameworks/getting_started/next.md
+++ b/src/guides/v7/sites_frameworks/getting_started/next.md
@@ -110,7 +110,17 @@ module.exports = with{{ PRODUCT }}({
 
 ## {{ PRODUCT_NAME }} Devtools {/* devtools */}
 
-By default, [Devtools](/guides/performance/observability/devtools) are enabled on production builds of Next.js with {{ PRODUCT }}. To disable devtools in production, see [Config Options](#disableDevtools) for setting the `disableEdgioDevTools` flag.
+To understand better the caching mechanism, you can add {{ PRODUCT }} devtools to see the caching metrics. Add the following code to your _app.tsx file:
+```js filename='_app.js'
+
+import {useDevtools} from '@edgio/react';
+const MyApp = ({Component, pageProps}) => {
+  useDevtools();
+  // ... rest of your _app.js code
+};
+```
+
+You can control how devtools are displayed in production with {{ PRODUCT }} config, see [Config Options](#disableDevtools) for setting the `disableEdgioDevTools` flag.
 
 ## Running Locally {/* running-locally */}
 
@@ -200,6 +210,12 @@ const MyApp = ({Component, pageProps}) => {
   // ... rest of your _app.js code
 };
 ```
+
+<Callout type="info">
+
+From Next 13 when `app` folder is used, adding `useServiceWorker` hook may break the build, as all pages in `app` folder are by default server components. In order to avoid this, hooks must be placed in client components only. To do this, add `use client` directive at the top of the component.
+
+</Callout>
 
 ## Routing {/* routing */}
 

--- a/src/guides/v7/sites_frameworks/getting_started/next.md
+++ b/src/guides/v7/sites_frameworks/getting_started/next.md
@@ -210,7 +210,7 @@ const MyApp = ({Component, pageProps}) => {
 
 <Callout type="info">
 
-From Next 13 when `app` folder is used, adding `useServiceWorker` hook may break the build, as all pages in `app` folder are by default server components. In order to avoid this, hooks must be placed in client components only. To do this, add `use client` directive at the top of the component.
+Starting with Next.js 13, when the `app` directory is used, adding `useServiceWorker` hook may break the build, as all pages in the `app` directory are by default server components. In order to avoid this, hooks must be placed in a client-only component. To do this, add [`use client` directive](https://nextjs.org/docs/getting-started/react-essentials#the-use-client-directive) at the top of the component.
 
 </Callout>
 

--- a/src/guides/v7/sites_frameworks/getting_started/next.md
+++ b/src/guides/v7/sites_frameworks/getting_started/next.md
@@ -36,11 +36,15 @@ For details on using the Next.js Commerce template with {{ PRODUCT }}, refer to 
 - [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props)
 - [`getInitialProps`](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props)
 
-## Connector {/*connector*/}
+## Connector {/* connector */}
 
 This framework has a connector developed for {{ PRODUCT }}. See [Connectors](/guides/sites_frameworks/connectors) for more information.
 
-<ButtonLink variant="stroke" type="code" withIcon={true} href="https://github.com/edgio-docs/edgio-connectors/tree/main/edgio-next-connector">
+<ButtonLink
+  variant="stroke"
+  type="code"
+  withIcon={true}
+  href="https://github.com/edgio-docs/edgio-connectors/tree/main/edgio-next-connector">
   View the Connector Code
 </ButtonLink>
 
@@ -114,10 +118,12 @@ To understand better the caching mechanism, you can add {{ PRODUCT }} Devtools t
 
 ```js filename='_app.tsx'
 import {useDevtools} from '@edgio/react';
+
 const MyApp = ({Component, pageProps}) => {
   useDevtools();
-  // ... rest of your _app.js code
+  // ... rest of your _app.tsx code
 };
+```
 
 ## Running Locally {/* running-locally */}
 

--- a/src/guides/v7/sites_frameworks/getting_started/next.md
+++ b/src/guides/v7/sites_frameworks/getting_started/next.md
@@ -110,17 +110,14 @@ module.exports = with{{ PRODUCT }}({
 
 ## {{ PRODUCT_NAME }} Devtools {/* devtools */}
 
-To understand better the caching mechanism, you can add {{ PRODUCT }} devtools to see the caching metrics. Add the following code to your _app.tsx file:
-```js filename='_app.js'
+To understand better the caching mechanism, you can add {{ PRODUCT }} Devtools to see the caching metrics. Add the following code to your `_app.tsx` file:
 
+```js filename='_app.tsx'
 import {useDevtools} from '@edgio/react';
 const MyApp = ({Component, pageProps}) => {
   useDevtools();
   // ... rest of your _app.js code
 };
-```
-
-You can control how devtools are displayed in production with {{ PRODUCT }} config, see [Config Options](#disableDevtools) for setting the `disableEdgioDevTools` flag.
 
 ## Running Locally {/* running-locally */}
 


### PR DESCRIPTION
We changed how devtools are injected, so this PR should cover this.

Also, note added for Next 13, as by default injecting SW on root components (app folder) will fail the build.