### PR TITLE
[COMSUP-153] Use JSURL to serialize search result instead of encodedURIComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "hast-util-heading-rank": "^1.0.1",
     "husky": "^7.0.4",
     "is-ci": "^3.0.1",
+    "jsurl": "^0.1.5",
     "lint-staged": ">=10",
     "lodash": "^4.17.21",
     "mdast-util-to-string": "^1.1.0",

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,4 +1,5 @@
 import {DocSearch} from '@docsearch/react';
+// @ts-ignore
 import {default as JSURL} from 'jsurl';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -16,8 +17,6 @@ import {siteConfig} from 'config/appConfig';
 import {getVersionedConfig} from 'utils/config';
 import useConditioning from 'utils/hooks/useConditioning';
 import useTheme from 'utils/hooks/useTheme';
-
-// @ts-ignore
 
 const StyledHeader = styled.header`
   position: sticky;

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,4 +1,5 @@
 import {DocSearch} from '@docsearch/react';
+import {default as JSURL} from 'jsurl';
 import Image from 'next/image';
 import Link from 'next/link';
 import styled from 'styled-components';
@@ -15,6 +16,8 @@ import {siteConfig} from 'config/appConfig';
 import {getVersionedConfig} from 'utils/config';
 import useConditioning from 'utils/hooks/useConditioning';
 import useTheme from 'utils/hooks/useTheme';
+
+// @ts-ignore
 
 const StyledHeader = styled.header`
   position: sticky;
@@ -212,7 +215,7 @@ function transformItems(items: any) {
     }
 
     if (matchedText) {
-      url.hash = btoa(unescape(encodeURIComponent(matchedText)));
+      url.hash = JSURL.stringify({q: matchedText});
     }
 
     return {

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore
 import {default as JSURL} from 'jsurl';
 import debounce from 'lodash/debounce';
 import Link from 'next/link';
@@ -16,8 +17,6 @@ import {useIsMobile} from './useMediaQuery';
 
 import useConditioning from 'utils/hooks/useConditioning';
 import textCompare from 'utils/textCompare';
-
-// @ts-ignore
 
 export function Page({children}: PageProps) {
   const isMobile = useIsMobile(850);

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -1,3 +1,4 @@
+import {default as JSURL} from 'jsurl';
 import debounce from 'lodash/debounce';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
@@ -15,6 +16,8 @@ import {useIsMobile} from './useMediaQuery';
 
 import useConditioning from 'utils/hooks/useConditioning';
 import textCompare from 'utils/textCompare';
+
+// @ts-ignore
 
 export function Page({children}: PageProps) {
   const isMobile = useIsMobile(850);
@@ -35,9 +38,12 @@ export function Page({children}: PageProps) {
       }
 
       try {
-        const highlight = decodeURIComponent(escape(atob(hash)));
-        if (highlight.length > 0 && contentInnerRef.current) {
-          highlightElementByText(highlight as string, contentInnerRef.current);
+        const highlight = JSURL.parse(hash);
+        if (highlight?.q?.length > 0 && contentInnerRef.current) {
+          highlightElementByText(
+            highlight.q as string,
+            contentInnerRef.current
+          );
         }
       } catch (e) {}
     }, 100);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7560,6 +7560,11 @@ jss@10.10.0, jss@^10.5.1:
     is-in-browser "^1.1.3"
     tiny-warning "^1.0.2"
 
+jsurl@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/jsurl/-/jsurl-0.1.5.tgz#2a5c8741de39cacafc12f448908bf34e960dcee8"
+  integrity sha512-HyrafsIRCa+VlJAsvuvxWUM0iMeZd6+2J4JngECGF0JTRi5moUFV/mLxgyYfDizGF4ofLLYRpvD/Kt1d9wlUUg==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"


### PR DESCRIPTION
Reduces conflict of some encoded characters in the hash.

Before: `https://docs.edg.io/guides/v7/logs/server_logs#RGVlcCBSZXF1ZXN0IEluc3BlY3Rpb24gKERSSSk=`
After:    `https://docs.edg.io/guides/v7/logs/server_logs#~(q~'Deep*20Request*20Inspection*20*28DRI*29)`

Also follows similar pattern to Chrome's *Copy Link to Highlight*: `https://docs.edg.io/guides/v7/logs/server_logs#:~:text=Deep%20Request%20Inspection%20(DRI)%20%23`