### PR TITLE
504 status code, add troubleshooting cross-reference to TLS 

### DIFF
--- a/src/guides/v7/basics/origins.md
+++ b/src/guides/v7/basics/origins.md
@@ -119,7 +119,7 @@ An origin configuration's TLS settings determine how {{ PRODUCT }} will communic
 
 -   By default, our network disables delivery and responds with a `502 Bad Gateway` when we detect an origin server using a self-signed certificate during the TLS handshake. Allow {{ PRODUCT }} to serve traffic when it detects a self-signed certificate by enabling the **Allow Self-Signed Certs** option. <a id="certificate-pinning" />
 -   Register the SHA-256 digest for the public key of your end-entity (i.e., leaf) certificate within the **Pinned Cert(s)** option. After which, our edge servers will respond with a `502 Bad Gateway` response when the SHA-256 digest for the public key detected from the origin server does not match one of the pinned certificates.
--   An invalid origin configuration, as described above, may also return a `504 Gateway Timeout` response instead of a `502 Bad Gateway`. You may [troubleshoot both status codes](/guides/performance/troubleshooting#502-bad-gateway-status-code) using the same steps.
+-   An invalid TLS configuration, as described above, may result in a `504 Gateway Timeout` response instead of a `502 Bad Gateway`. You may [troubleshoot both status codes](/guides/performance/troubleshooting#502-bad-gateway-status-code) using the same steps.
 
 ## System-Defined Origins {/*system-defined-origins*/}
 

--- a/src/guides/v7/basics/origins.md
+++ b/src/guides/v7/basics/origins.md
@@ -119,6 +119,7 @@ An origin configuration's TLS settings determine how {{ PRODUCT }} will communic
 
 -   By default, our network disables delivery and responds with a `502 Bad Gateway` when we detect an origin server using a self-signed certificate during the TLS handshake. Allow {{ PRODUCT }} to serve traffic when it detects a self-signed certificate by enabling the **Allow Self-Signed Certs** option. <a id="certificate-pinning" />
 -   Register the SHA-256 digest for the public key of your end-entity (i.e., leaf) certificate within the **Pinned Cert(s)** option. After which, our edge servers will respond with a `502 Bad Gateway` response when the SHA-256 digest for the public key detected from the origin server does not match one of the pinned certificates.
+-   An invalid origin configuration, as described above, may also return a `504 Gateway Timeout` response instead of a `502 Bad Gateway`. You may [troubleshoot both status codes](/guides/performance/troubleshooting#502-bad-gateway-status-code) using the same steps.
 
 ## System-Defined Origins {/*system-defined-origins*/}
 

--- a/src/guides/v7/performance/troubleshooting.md
+++ b/src/guides/v7/performance/troubleshooting.md
@@ -304,6 +304,12 @@ Troubleshoot this status code by performing the following steps:
     -   **No:** {{ PRODUCT }} requires a full chain certificate. Your certificate’s chain of trust must start with the server's certificate and terminate with the root certificate.
 -   If you have pinned a certificate to the desired origin configuration, then you may need to pin an additional certificate.
 
+### 504 Gateway Timeout Status Code {/*504-gateway-timeout-status-code*/}
+
+Server error response code indicates that the server, while acting as a gateway or proxy, did not get a response in time from the upstream server that it needed in order to complete the request.
+
+Troubleshoot the status code with similar steps as error code 502. Usually an indication that SSL is not setup correctly yet. 
+
 ### 531 Project Upstream Connection Error Status Code {/*531-project-upstream-connection-error-status-code*/}
 
 Common causes are:  

--- a/src/guides/v7/performance/troubleshooting.md
+++ b/src/guides/v7/performance/troubleshooting.md
@@ -306,9 +306,7 @@ Troubleshoot this status code by performing the following steps:
 
 ### 504 Gateway Timeout Status Code {/*504-gateway-timeout-status-code*/}
 
-Server error response code indicates that the server, while acting as a gateway or proxy, did not get a response in time from the upstream server that it needed in order to complete the request.
-
-Troubleshoot the status code with similar steps as error code 502. Usually an indication that SSL is not setup correctly yet. 
+Troubleshoot this status code in the same manner as a [502 Bad Gateway status code](#502-bad-gateway-status-code).
 
 ### 531 Project Upstream Connection Error Status Code {/*531-project-upstream-connection-error-status-code*/}
 

--- a/src/guides/v7/security/tls_certificates.md
+++ b/src/guides/v7/security/tls_certificates.md
@@ -300,4 +300,4 @@ Uploading a TLS certificate requires:
 
 ### Troubleshooting {/*troubleshooting*/}
 
-If you experience either a `502 Bad Gateway` or a `504 Gateway Timeout` after completing TLS setup, then your origin may be improperly configured. [View troubleshooting steps.](/guides/performance/troubleshooting#502-bad-gateway-status-code) 
+If your origin returns a `502 Bad Gateway` or a `504 Gateway Timeout` response when served through {{ PRODUCT }}, then your origin configuration's TLS settings may be improperly configured. [View troubleshooting steps.](/guides/performance/troubleshooting#502-bad-gateway-status-code) 

--- a/src/guides/v7/security/tls_certificates.md
+++ b/src/guides/v7/security/tls_certificates.md
@@ -296,3 +296,8 @@ Uploading a TLS certificate requires:
       Contact technical customer support if the status does not become *Active* within an hour.
 
     </Callout>
+
+
+### Troubleshooting 
+
+If errors are encountered during setup, like HTTP 502 or 504 errors, visit the [Troubleshooting](/guides/performance/troubleshooting#502-bad-gateway-status-code) page for steps to follow. 

--- a/src/guides/v7/security/tls_certificates.md
+++ b/src/guides/v7/security/tls_certificates.md
@@ -298,6 +298,6 @@ Uploading a TLS certificate requires:
     </Callout>
 
 
-### Troubleshooting 
+### Troubleshooting {/*troubleshooting*/}
 
-If errors are encountered during setup, like HTTP 502 or 504 errors, visit the [Troubleshooting](/guides/performance/troubleshooting#502-bad-gateway-status-code) page for steps to follow. 
+If you experience either a `502 Bad Gateway` or a `504 Gateway Timeout` after completing TLS setup, then your origin may be improperly configured. [View troubleshooting steps.](/guides/performance/troubleshooting#502-bad-gateway-status-code) 


### PR DESCRIPTION
adds another common use case encountered during setup 