### PR TITLE
Invalid links in v4 guides

### DIFF
--- a/guides/applications/v4/production.md
+++ b/guides/applications/v4/production.md
@@ -8,7 +8,7 @@ Creating custom domains is always done in the context of creating or updating an
 
 ## Configuration Overview {/*configuration-overview*/}
 
-1. If needed, create an environment using instructions in  [Environments](./environments).
+1. If needed, create an environment using instructions in  [Environments](environments).
 
 2. Create the [Custom Domain](#section_domains).
 
@@ -22,7 +22,7 @@ Before going live, you must create a production environment and configure your d
 
 To configure your custom domains:
 
-1. Navigate to a site, then open an existing environment or create a new environment. (To create an environment, use instructions in [Environments](./environments).)
+1. Navigate to a site, then open an existing environment or create a new environment. (To create an environment, use instructions in [Environments](environments).)
    * For an existing environment, select the _ENVIRONMENTS_ tab header, then click an environment name in the list of environments. Continue with the numbered steps below.
    * For a new environment, the _DEPLOYMENTS_ tab is displayed. Continue with the following steps.
 

--- a/guides/applications/v4/teams.md
+++ b/guides/applications/v4/teams.md
@@ -22,7 +22,7 @@ After launching your site, your  private space will look similar to this example
 
 When you run `{{ CLI_NAME }} deploy` your site will be created here. Sites in your private space can only be seen by you. To collaborate with other developers, create a team.
 
-To create a team, click the diamond icon to the right of your name in the upper left of your window, then choose *Create a team* from the popup. 
+To create a team, click the diamond icon to the right of your name in the upper left of your window, then choose *Create a team* from the popup.
 
 ![create team icon](/images/teams/create-team-icon.png?width=300px)
 
@@ -30,7 +30,7 @@ Enter a name in the *Add a Team* dialog and click *CREATE A TEAM*.
 
 ![create dialog](/images/teams/create_dialog.png)
 
-The name you choose also determines the default URL from which your site will be accessible. To configure custom domains, see [Environments](./environments).
+The name you choose also determines the default URL from which your site will be accessible. To configure custom domains, see [Environments](environments).
 
 ## Adding Your Website to the Team {/*adding-your-website-to-the-team*/}
 
@@ -38,7 +38,7 @@ After you create the team, the *Get Started* dialog is displayed (see [Launching
 
 ## Adding Team Members {/*adding-team-members*/}
 
-You add members by supplying an email address and inviting them. 
+You add members by supplying an email address and inviting them.
 
 Click your team name in the page header, then click the _Team Members_ tab:
 


### PR DESCRIPTION
Discovered by crawl, resulted in `/[product]/environments` as the path.