### PR TITLE
Document Edge Function Request.url changes

### DIFF
--- a/guides/applications/v7/edge_functions.md
+++ b/guides/applications/v7/edge_functions.md
@@ -211,7 +211,13 @@ Edge functions are passed a `Request` instance representing the incoming request
   - **JSON**: `await request.json()`
   - **Text**: `await request.text()`
 - **Method**: `request.method` to get the HTTP method of the request.
-- **URL**: `request.url` provides the full URL, and `request.path` gives the request path.
+- **URL**:
+  - `request.url`: Provides the full URL.
+  - `request.path`: Provides the request path.
+  - `request.originalUrl`: Requires {{ PRODUCT }} version 7.13.6 or later. Provides the original URL sent by the user-agent. This property is only present on the incoming request provided to the `handleHttpRequest` handler.
+  <Important>
+  As of {{ PRODUCT }} version 7.13.6, the `request.path` and `request.url` properties return the [rewritten](/applications/performance/rules/features#rewrite-url) path or URL, respectively. 
+  </Important>
 - **Cloning**: To clone a request without its body, use `request.cloneWithoutBody()`.
 
 #### Unsupported Methods and Properties {/* request-unsupported-methods-and-properties */}


### PR DESCRIPTION
Documentation for Request URL changes to the Edge Function `Request` class in v7.13.6